### PR TITLE
Add Google as a provider in auth.ts

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,12 +1,13 @@
 import NextAuth from 'next-auth';
 import GitHub from 'next-auth/providers/github';
 import Discord from 'next-auth/providers/discord';
+import Google from 'next-auth/providers/google';
 import { DrizzleAdapter } from '@auth/drizzle-adapter';
 import { database } from '@/db/database';
 import { users, accounts, sessions, verificationTokens } from '@/db/schema';
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
-  providers: [GitHub, Discord],
+  providers: [GitHub, Discord, Google],
   adapter: DrizzleAdapter(database, {
     usersTable: users,
     accountsTable: accounts,


### PR DESCRIPTION
This commit adds the Google provider to the list of providers in auth.ts, allowing users to sign in with their Google accounts.