### PR TITLE
feat: Add plate number and state to comments page

### DIFF
--- a/src/app/(admin)/dashboard/comments/page.tsx
+++ b/src/app/(admin)/dashboard/comments/page.tsx
@@ -6,7 +6,7 @@ import NotAuthenticated from '@/components/dashboard/not-authenticated';
 
 import { database } from '@/db/database';
 import { desc, eq } from 'drizzle-orm';
-import { comments, users } from '@/db/schema';
+import { comments, users, plates } from '@/db/schema';
 import { DataTable } from '@/components/dashboard/data-table';
 import { commentsColumn } from '@/components/dashboard/comments-column';
 import LoginPage from '@/components/dashboard/login-page';
@@ -32,9 +32,12 @@ export default async function CommentsPage() {
       comment: comments.comment,
       timestamp: comments.timestamp,
       userEmail: users.email,
+      plateNumber: plates.plateNumber,
+      state: plates.state,
     })
     .from(comments)
     .leftJoin(users, eq(comments.userId, users.id))
+    .leftJoin(plates, eq(comments.plateId, plates.id))
     .orderBy(desc(comments.timestamp));
 
   return (

--- a/src/components/dashboard/comments-column.tsx
+++ b/src/components/dashboard/comments-column.tsx
@@ -14,6 +14,8 @@ export type Comment = {
   comment: string;
   timestamp: Date;
   userEmail: string | null;
+  plateNumber: string | null;
+  state: string | null;
 };
 
 export const commentsColumn: ColumnDef<Comment>[] = [
@@ -45,6 +47,32 @@ export const commentsColumn: ColumnDef<Comment>[] = [
           variant='ghost'
           onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
           User
+          <ArrowUpDown className='ml-2 h-4 w-4' />
+        </Button>
+      );
+    },
+  },
+  {
+    accessorKey: 'plateNumber',
+    header: ({ column }) => {
+      return (
+        <Button
+          variant='ghost'
+          onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+          Plate
+          <ArrowUpDown className='ml-2 h-4 w-4' />
+        </Button>
+      );
+    },
+  },
+  {
+    accessorKey: 'state',
+    header: ({ column }) => {
+      return (
+        <Button
+          variant='ghost'
+          onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+          State
           <ArrowUpDown className='ml-2 h-4 w-4' />
         </Button>
       );


### PR DESCRIPTION
This commit adds the `plateNumber` and `state` fields to the comments page in the admin dashboard. The code changes include importing the `plates` schema, joining it with the existing tables, and displaying the new columns in the data table.