### PR TITLE
feat: Add user-specific comments retrieval in Account page

### DIFF
--- a/src/app/(public)/account/page.tsx
+++ b/src/app/(public)/account/page.tsx
@@ -28,6 +28,7 @@ export default async function Account() {
       state: plates.state,
     })
     .from(comments)
+    .where(eq(comments.userId, user?.id!))
     .leftJoin(plates, eq(comments.plateId, plates.id))
     .orderBy(desc(comments.timestamp));
 


### PR DESCRIPTION
This commit adds a new query to retrieve comments specific to the logged-in user on the Account page. The query filters the comments based on the user's ID and joins them with the plates table. This change enhances the user experience by displaying personalized comments on their account page.

RIP I did not filter by user id and it caused all comments to be shown in the table