### PR TITLE
Removes overflow clipping from marquee sections

### DIFF
--- a/src/components/public/plate-sections/recently-rated-section.tsx
+++ b/src/components/public/plate-sections/recently-rated-section.tsx
@@ -61,7 +61,7 @@ async function RecentlyRatedMarquee() {
   const row2 = reviewsWithState.slice(mid);
 
   return (
-    <div className="relative overflow-hidden">
+    <div className="relative">
       <div className="pointer-events-none absolute left-0 top-0 bottom-0 w-16 sm:w-32 z-10 bg-linear-to-r from-background to-transparent" />
       <div className="pointer-events-none absolute right-0 top-0 bottom-0 w-16 sm:w-32 z-10 bg-linear-to-l from-background to-transparent" />
       <div className="flex flex-col gap-4">

--- a/src/components/public/review-marquee.tsx
+++ b/src/components/public/review-marquee.tsx
@@ -105,7 +105,7 @@ export default function ReviewMarquee({
   const style = { animationDuration: `${duration}s` };
 
   return (
-    <div ref={containerRef} className="flex overflow-hidden">
+    <div ref={containerRef} className="flex ">
       {[0, 1].map((copy) => (
         <div
           key={copy}


### PR DESCRIPTION
Removes overflow clipping on marquee-related containers to enable full animated overflow and prevent content from being cut off at container edges, improving visual continuity of the scrolling reviews.